### PR TITLE
Disable Codex shell snapshot by default

### DIFF
--- a/src/commands/codex.mjs
+++ b/src/commands/codex.mjs
@@ -1,4 +1,8 @@
-import { CODEX_MODEL, USE_UNSAFE_CODEX } from "../config.mjs";
+import {
+  CODEX_DISABLE_SHELL_SNAPSHOT,
+  CODEX_MODEL,
+  USE_UNSAFE_CODEX,
+} from "../config.mjs";
 
 export function buildCodexArgs(prompt, workdir) {
   const args = [];
@@ -7,6 +11,10 @@ export function buildCodexArgs(prompt, workdir) {
 
   // Force a known model for every invocation (unless overridden via env)
   args.push("--model", CODEX_MODEL);
+
+  if (CODEX_DISABLE_SHELL_SNAPSHOT) {
+    args.push("--disable", "shell_snapshot");
+  }
 
   if (USE_UNSAFE_CODEX) {
     args.push("--dangerously-bypass-approvals-and-sandbox");

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -15,6 +15,8 @@ export const CODEX_MODEL = process.env.CODEX_MODEL || "gpt-5.1-codex-max";
 
 export const CODEX_TIMEOUT_MS = Number(process.env.CODEX_TIMEOUT_MS || 60 * 60 * 1000);
 export const USE_UNSAFE_CODEX = String(process.env.USE_UNSAFE_CODEX || "1") === "1";
+export const CODEX_DISABLE_SHELL_SNAPSHOT =
+  String(process.env.CODEX_DISABLE_SHELL_SNAPSHOT || "1") === "1";
 
 export const TELEGRAM_SEND_DELAY_MS = Number(process.env.TELEGRAM_SEND_DELAY_MS || 900);
 export const TELEGRAM_MAX_CHARS = Number(process.env.TELEGRAM_MAX_CHARS || 3500);


### PR DESCRIPTION
## Summary
- disable Codex shell_snapshot by default to avoid macOS script -f error
- allow opt-out via CODEX_DISABLE_SHELL_SNAPSHOT env flag

## Testing
- not run (config change only)